### PR TITLE
Upgrade the production version to 9.4.4

### DIFF
--- a/src/main/java/ru/yandex/qatools/embed/postgresql/distribution/Version.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/distribution/Version.java
@@ -7,10 +7,11 @@ import de.flapdoodle.embed.process.distribution.IVersion;
  */
 public enum Version implements IVersion {
 
+    V9_4_4("9.4.4-1"),
+
     /**
      * 9.3.6 release
      */
-    V9_4_1("9.4.1-1"),
     V9_3_6("9.3.6-1"),
     @Deprecated
     V9_2_4("9.2.4-1"),;
@@ -39,9 +40,9 @@ public enum Version implements IVersion {
          */
         @Deprecated
         V9_3(V9_3_6),
-        V9_4(V9_4_1),
+        V9_4(V9_4_4),
 
-        PRODUCTION(V9_4_1);
+        PRODUCTION(V9_4_4);
 
         private final IVersion _latest;
 


### PR DESCRIPTION
The latest version was released on June, 12.
The release notes: http://www.postgresql.org/docs/9.4/static/release-9-4-4.html