### PR TITLE
Defaulting to less verbose progress logging when running commands

### DIFF
--- a/src/main/java/ru/yandex/qatools/embed/postgresql/PostgresProcess.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/PostgresProcess.java
@@ -6,10 +6,14 @@ import de.flapdoodle.embed.process.distribution.Distribution;
 import de.flapdoodle.embed.process.extract.IExtractedFileSet;
 import de.flapdoodle.embed.process.io.LoggingOutputStreamProcessor;
 import de.flapdoodle.embed.process.io.directories.IDirectory;
+import de.flapdoodle.embed.process.io.progress.LoggingProgressListener;
 import de.flapdoodle.embed.process.runtime.Executable;
 import de.flapdoodle.embed.process.runtime.ProcessControl;
+
+import ru.yandex.qatools.embed.postgresql.config.DownloadConfigBuilder;
 import ru.yandex.qatools.embed.postgresql.config.PostgresConfig;
 import ru.yandex.qatools.embed.postgresql.config.RuntimeConfigBuilder;
+import ru.yandex.qatools.embed.postgresql.ext.ArtifactStoreBuilder;
 import ru.yandex.qatools.embed.postgresql.ext.LogWatchStreamProcessor;
 import ru.yandex.qatools.embed.postgresql.ext.PostgresArtifactStore;
 
@@ -68,6 +72,9 @@ public class PostgresProcess extends AbstractPGProcess<PostgresExecutable, Postg
             final RuntimeConfigBuilder rtConfigBuilder = new RuntimeConfigBuilder().defaults(cmd);
             IRuntimeConfig runtimeConfig = rtConfigBuilder
                     .processOutput(new ProcessOutput(logWatch, logWatch, logWatch))
+                    .artifactStore(new ArtifactStoreBuilder().defaults(cmd)
+                            .download(new DownloadConfigBuilder().defaultsForCommand(cmd)
+                                .progressListener(new LoggingProgressListener(logger, Level.ALL))))
                     .build();
             Executable exec = getCommand(cmd, runtimeConfig)
                     .prepare(new PostgresConfig(config).withArgs(args));

--- a/src/test/java/ru/yandex/qatools/embed/postgresql/TestPostgresStarter.java
+++ b/src/test/java/ru/yandex/qatools/embed/postgresql/TestPostgresStarter.java
@@ -4,11 +4,20 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import ru.yandex.qatools.embed.postgresql.config.AbstractPostgresConfig;
+import ru.yandex.qatools.embed.postgresql.config.DownloadConfigBuilder;
 import ru.yandex.qatools.embed.postgresql.config.PostgresConfig;
+import ru.yandex.qatools.embed.postgresql.config.RuntimeConfigBuilder;
+import ru.yandex.qatools.embed.postgresql.ext.ArtifactStoreBuilder;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.not;
@@ -18,18 +27,39 @@ import static org.junit.Assert.assertThat;
 import static ru.yandex.qatools.embed.postgresql.distribution.Version.Main.PRODUCTION;
 import static ru.yandex.qatools.embed.postgresql.util.SocketUtil.findFreePort;
 
+import de.flapdoodle.embed.process.config.IRuntimeConfig;
+import de.flapdoodle.embed.process.io.progress.LoggingProgressListener;
+import de.flapdoodle.embed.process.io.progress.Slf4jProgressListener;
+
 public class TestPostgresStarter {
+
+    private static final Logger logger = Logger.getLogger(TestPostgresStarter.class.getName());
 
     private PostgresProcess process;
     private Connection conn;
+    private final TestHandler testHandler = new TestHandler();
 
     @Before
     public void setUp() throws Exception {
-        PostgresStarter<PostgresExecutable, PostgresProcess> runtime = PostgresStarter.getDefaultInstance();
+        logger.setLevel(Level.INFO);
+        logger.addHandler(testHandler);
+        // turns off the default functionality of unzipping on every run.
+        IRuntimeConfig runtimeConfig = new RuntimeConfigBuilder()
+                .defaults(Command.Postgres)
+                .artifactStore(new ArtifactStoreBuilder()
+                        .defaults(Command.Postgres)
+                        .download(new DownloadConfigBuilder()
+                                .defaultsForCommand(Command.Postgres)
+                                .progressListener(new LoggingProgressListener(logger, Level.ALL))))
+
+                .build();
+
+        PostgresStarter<PostgresExecutable, PostgresProcess> runtime = PostgresStarter.getInstance(runtimeConfig);
         final PostgresConfig config = new PostgresConfig(PRODUCTION, new AbstractPostgresConfig.Net(
                 "localhost", findFreePort()
         ), new AbstractPostgresConfig.Storage("test"), new AbstractPostgresConfig.Timeout(),
                 new AbstractPostgresConfig.Credentials("user", "password"));
+
         PostgresExecutable exec = runtime.prepare(config);
         process = exec.start();
         String url = format("jdbc:postgresql://%s:%s/%s?user=%s&password=%s",
@@ -57,5 +87,28 @@ public class TestPostgresStarter {
         assertThat(statement.execute("SELECT * FROM films;"), is(true));
         assertThat(statement.getResultSet().next(), is(true));
         assertThat(statement.getResultSet().getString("code"), is("movie"));
+
+        // verify no logs
+        assertThat(testHandler.RECORDS.size(), is(0));
+    }
+
+    private static class TestHandler extends Handler {
+
+        public final List<LogRecord> RECORDS = new ArrayList<>();
+
+        @Override
+        public void publish(LogRecord record) {
+            RECORDS.add(record);
+        }
+
+        @Override
+        public void flush() {
+
+        }
+
+        @Override
+        public void close() throws SecurityException {
+
+        }
     }
 }


### PR DESCRIPTION
Fixes #18 

This fix passes in the `logger` when calling `runCmd` instead of writing to `System.out`. 