### PR TITLE
Allow running as another user

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.3</version>
                 <configuration>
                     <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,30 @@
             <version>1.0.9</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>1.7.10</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <version>1.7.10</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.10</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/src/main/java/ru/yandex/qatools/embed/postgresql/PostgresProcess.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/PostgresProcess.java
@@ -9,7 +9,6 @@ import de.flapdoodle.embed.process.io.directories.IDirectory;
 import de.flapdoodle.embed.process.io.progress.LoggingProgressListener;
 import de.flapdoodle.embed.process.runtime.Executable;
 import de.flapdoodle.embed.process.runtime.ProcessControl;
-
 import ru.yandex.qatools.embed.postgresql.config.DownloadConfigBuilder;
 import ru.yandex.qatools.embed.postgresql.config.PostgresConfig;
 import ru.yandex.qatools.embed.postgresql.config.RuntimeConfigBuilder;
@@ -21,7 +20,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -31,7 +34,9 @@ import static java.lang.Thread.sleep;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.apache.commons.io.FileUtils.readLines;
-import static ru.yandex.qatools.embed.postgresql.Command.*;
+import static ru.yandex.qatools.embed.postgresql.Command.CreateDb;
+import static ru.yandex.qatools.embed.postgresql.Command.InitDb;
+import static ru.yandex.qatools.embed.postgresql.Command.Psql;
 import static ru.yandex.qatools.embed.postgresql.PostgresStarter.getCommand;
 import static ru.yandex.qatools.embed.postgresql.config.AbstractPostgresConfig.Storage;
 
@@ -50,35 +55,36 @@ public class PostgresProcess extends AbstractPGProcess<PostgresExecutable, Postg
         this.runtimeConfig = runtimeConfig;
     }
 
+    /**
+     * @deprecated consider using {@link #stop()} method instead
+     */
+    @Deprecated
     public static boolean shutdownPostgres(PostgresConfig config) {
-        try {
-            return runCmd(config, Command.PgCtl, "server stopped", 1000, "stop");
-        } catch (Exception e) {
-            logger.log(Level.WARNING, "Failed to stop postgres by pg_ctl!");
-        }
-        return false;
+        return shutdownPostgres(config, new RuntimeConfigBuilder().defaults(Command.PgCtl).build());
     }
 
-    private static <P extends AbstractPGProcess> boolean runCmd(
-            PostgresConfig config, Command cmd, String successOutput, int timoeut, String... args) {
-        return runCmd(config, cmd, successOutput, Collections.<String>emptySet(), timoeut, args);
+    private static boolean runCmd(
+            PostgresConfig config, IRuntimeConfig runtimeConfig, Command cmd, String successOutput, int timoeut, String... args) {
+        return runCmd(config, runtimeConfig, cmd, successOutput, Collections.<String>emptySet(), timoeut, args);
     }
 
-    private static <P extends AbstractPGProcess> boolean runCmd(
-            PostgresConfig config, Command cmd, String successOutput, Set<String> failOutput, long timeout, String... args) {
+    private static boolean runCmd(
+            PostgresConfig config, IRuntimeConfig runtimeConfig, Command cmd, String successOutput, Set<String> failOutput, long timeout, String... args) {
         try {
             LogWatchStreamProcessor logWatch = new LogWatchStreamProcessor(successOutput,
                     failOutput, new LoggingOutputStreamProcessor(logger, Level.ALL));
-            final RuntimeConfigBuilder rtConfigBuilder = new RuntimeConfigBuilder().defaults(cmd);
-            IRuntimeConfig runtimeConfig = rtConfigBuilder
+
+            IRuntimeConfig runtimeCfg = new RuntimeConfigBuilder().defaults(cmd)
                     .processOutput(new ProcessOutput(logWatch, logWatch, logWatch))
                     .artifactStore(new ArtifactStoreBuilder().defaults(cmd)
                             .download(new DownloadConfigBuilder().defaultsForCommand(cmd)
-                                .progressListener(new LoggingProgressListener(logger, Level.ALL))))
+                                    .progressListener(new LoggingProgressListener(logger, Level.ALL))))
+                    .commandLinePostProcessor(runtimeConfig.getCommandLinePostProcessor())
                     .build();
-            Executable exec = getCommand(cmd, runtimeConfig)
+
+            Executable<?, ? extends AbstractPGProcess> exec = getCommand(cmd, runtimeCfg)
                     .prepare(new PostgresConfig(config).withArgs(args));
-            P proc = (P) exec.start();
+            AbstractPGProcess proc = exec.start();
             logWatch.waitForResult(timeout);
             proc.waitFor();
             return true;
@@ -119,7 +125,7 @@ public class PostgresProcess extends AbstractPGProcess<PostgresExecutable, Postg
     }
 
     protected final boolean sendStopToPostgresqlInstance() {
-        final boolean result = shutdownPostgres(getConfig());
+        final boolean result = shutdownPostgres(getConfig(), runtimeConfig);
         if (runtimeConfig.getArtifactStore() instanceof PostgresArtifactStore) {
             final IDirectory tempDir = ((PostgresArtifactStore) runtimeConfig.getArtifactStore()).getTempDir();
             if (tempDir != null && tempDir.asFile() != null) {
@@ -131,12 +137,21 @@ public class PostgresProcess extends AbstractPGProcess<PostgresExecutable, Postg
         return result;
     }
 
+    private static boolean shutdownPostgres(PostgresConfig config, IRuntimeConfig runtimeConfig) {
+        try {
+            return runCmd(config, runtimeConfig, Command.PgCtl, "server stopped", 1000, "stop");
+        } catch (Exception e) {
+            logger.log(Level.WARNING, "Failed to stop postgres by pg_ctl!");
+        }
+        return false;
+    }
+
     @Override
     protected void onBeforeProcess(IRuntimeConfig runtimeConfig)
             throws IOException {
         super.onBeforeProcess(runtimeConfig);
         PostgresConfig config = getConfig();
-        runCmd(config, InitDb, "Success. You can now start the database server using", 1000);
+        runCmd(config, runtimeConfig, InitDb, "Success. You can now start the database server using", 1000);
     }
 
     @Override
@@ -184,7 +199,7 @@ public class PostgresProcess extends AbstractPGProcess<PostgresExecutable, Postg
             // fails
             setProcessId(getPidFromFile(pidFile()));
         }
-        runCmd(getConfig(), CreateDb, "", new HashSet<>(singletonList("database creation failed")),
+        runCmd(getConfig(), runtimeConfig, CreateDb, "", new HashSet<>(singletonList("database creation failed")),
                 1000, getConfig().storage().dbName());
     }
 
@@ -195,7 +210,7 @@ public class PostgresProcess extends AbstractPGProcess<PostgresExecutable, Postg
      */
     public void importFromFile(File file) {
         if (file.exists()) {
-            runCmd(getConfig(), Psql, "", new HashSet<>(singletonList("import into " + getConfig().storage().dbName() + " failed")),
+            runCmd(getConfig(), runtimeConfig, Psql, "", new HashSet<>(singletonList("import into " + getConfig().storage().dbName() + " failed")),
                     1000,
                     "-U", getConfig().credentials().username(),
                     "-d", getConfig().storage().dbName(),

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,8 @@
+# Root logger option
+log4j.rootLogger=DEBUG, stdout
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n


### PR DESCRIPTION
Happy New Year! :tada: 

In our CI the build is being run as root inside Docker container.
That prevents us from running embedded Postgres as `postgres`
refuses to start under root user.

Currently you can wrap postgres command with `su postgres -c <command>`, but that works only for the `postgres` command and not for `initdb` and others. That causes all sorts of permission issues.

This PR makes sure the same CommandLineProcessor is used for all commands run by `PostgresProcess`.
This allows to wrap all commands with `su postgres -c <command>`.