### PR TITLE
use pg_ctl wrapper instead of postgres

### DIFF
--- a/src/main/java/ru/yandex/qatools/embed/postgresql/Command.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/Command.java
@@ -3,7 +3,7 @@ package ru.yandex.qatools.embed.postgresql;
 import ru.yandex.qatools.embed.postgresql.config.PostgresConfig;
 
 public enum Command {
-    Postgres("postgres", PostgresExecutable.class),
+    Postgres("pg_ctl", PostgresExecutable.class),
     InitDb("initdb", InitDbExecutable.class),
     CreateDb("createdb", CreateDbExecutable.class),
     PgCtl("pg_ctl", PgCtlExecutable.class),

--- a/src/main/java/ru/yandex/qatools/embed/postgresql/PostgresProcess.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/PostgresProcess.java
@@ -20,7 +20,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -145,9 +149,11 @@ public class PostgresProcess extends AbstractPGProcess<PostgresExecutable, Postg
             throws IOException {
         List<String> ret = new ArrayList<>();
         ret.addAll(asList(exe.executable().getAbsolutePath(),
-                "-h", config.net().host(),
-                "-p", String.valueOf(config.net().port()),
-                "-D", config.storage().dbDir().getAbsolutePath()
+                "start",
+                "-o",
+                String.format("\"-p %s\"", String.valueOf(config.net().port())),
+                "-D", config.storage().dbDir().getAbsolutePath(),
+                "-w"
         ));
 
         return ret;

--- a/src/main/java/ru/yandex/qatools/embed/postgresql/PostgresProcess.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/PostgresProcess.java
@@ -151,7 +151,7 @@ public class PostgresProcess extends AbstractPGProcess<PostgresExecutable, Postg
         ret.addAll(asList(exe.executable().getAbsolutePath(),
                 "start",
                 "-o",
-                String.format("\"-p %s\"", String.valueOf(config.net().port())),
+                String.format("\"-p %s -h %s\"", config.net().port(), config.net().host()),
                 "-D", config.storage().dbDir().getAbsolutePath(),
                 "-w"
         ));

--- a/src/main/java/ru/yandex/qatools/embed/postgresql/PostgresProcess.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/PostgresProcess.java
@@ -151,7 +151,9 @@ public class PostgresProcess extends AbstractPGProcess<PostgresExecutable, Postg
         ret.addAll(asList(exe.executable().getAbsolutePath(),
                 "start",
                 "-o",
-                String.format("\"-p %s -h %s\"", config.net().port(), config.net().host()),
+                String.format("\"-p %s\"", config.net().port()),
+                "-o",
+                String.format("\"-h %s\"", config.net().host()),
                 "-D", config.storage().dbDir().getAbsolutePath(),
                 "-w"
         ));


### PR DESCRIPTION
use pg_ctl wrapper instead of postgres to start up pg db to avoid user with admin roles having issues on win, tested both on linux/win Github issue  https://github.com/yandex-qatools/postgresql-embedded/issues/28