### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,10 @@ Here is the example of how to launch and use the embedded PostgreSQL instance
     PostgresProcess process = exec.start();
     
     // connecting to a running Postgres
-    String url = format("jdbc:postgresql://%s:%s/%s?user=%s&password=%s",
+    String url = format("jdbc:postgresql://%s:%s/%s",
             config.net().host(),
             config.net().port(),
-            config.storage().dbName(),
-            config.credentials().username(),
-            config.credentials().password()
+            config.storage().dbName()
     );
     Connection conn = DriverManager.getConnection(url);
     


### PR DESCRIPTION
removed config.credentials() as this is a NullPointerException if you did not pass username/password into the configuration.

Could also be solved in code with some kind of default credential if you want to show using credentials in the readme.