### PR TITLE
psql CLI args

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ Here is the example of how to launch and use the embedded PostgreSQL instance
     // feeding up the database
     conn.createStatement().execute("CREATE TABLE films (code char(5));");
     conn.createStatement().execute("INSERT INTO films VALUES ('movie');");
+
+    // ... or you can execute SQL files...
+    //pgProcess.importFromFile(new File("someFile.sql"))
+    // ... or even SQL files with PSQL variables in them...
+    //pgProcess.importFromFileWithArgs(new File("someFile.sql"), "-v", "tblName=someTable")
     
     // performing some assertions
     final Statement statement = conn.createStatement();

--- a/src/main/java/ru/yandex/qatools/embed/postgresql/PostgresProcess.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/PostgresProcess.java
@@ -9,6 +9,7 @@ import de.flapdoodle.embed.process.io.directories.IDirectory;
 import de.flapdoodle.embed.process.io.progress.LoggingProgressListener;
 import de.flapdoodle.embed.process.runtime.Executable;
 import de.flapdoodle.embed.process.runtime.ProcessControl;
+import org.apache.commons.lang3.ArrayUtils;
 import ru.yandex.qatools.embed.postgresql.config.DownloadConfigBuilder;
 import ru.yandex.qatools.embed.postgresql.config.PostgresConfig;
 import ru.yandex.qatools.embed.postgresql.config.RuntimeConfigBuilder;
@@ -227,15 +228,27 @@ public class PostgresProcess extends AbstractPGProcess<PostgresExecutable, Postg
      * @param file The file to import into database
      */
     public void importFromFile(File file) {
+        importFromFileWithArgs(file);
+    }
+
+    /**
+     * Import into database from file with additional args
+     *
+     * @param file
+     * @param cliArgs additional arguments for psql (be sure to separate args from their values)
+     */
+    public void importFromFileWithArgs(File file,String... cliArgs) {
         if (file.exists()) {
-            runCmd(getConfig(), runtimeConfig, Psql, "", new HashSet<>(singletonList("import into " + getConfig().storage().dbName() + " failed")),
-                    1000,
+            String[] args = {
                     "-U", getConfig().credentials().username(),
                     "-d", getConfig().storage().dbName(),
                     "-h", getConfig().net().host(),
                     "-p", String.valueOf(getConfig().net().port()),
-                    "-f", file.getAbsolutePath()
-            );
+                    "-f", file.getAbsolutePath()};
+            if(cliArgs != null && cliArgs.length != 0) {
+                args = ArrayUtils.addAll(args, cliArgs);
+            }
+            runCmd(getConfig(), runtimeConfig, Psql, "", new HashSet<>(singletonList("import into " + getConfig().storage().dbName() + " failed")), 1000, args);
         }
     }
 


### PR DESCRIPTION
added ability to specify arbritrary arguments for psql command line during file import (such as variables that scripts need)
Please add this, it allows us to specify "-v blabla=abc" type variables for SQL scripts
