### PR TITLE
Use the same (possibly user-set) artifact store for all 3 commands

### DIFF
--- a/src/main/java/ru/yandex/qatools/embed/postgresql/PostgresProcess.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/PostgresProcess.java
@@ -6,14 +6,11 @@ import de.flapdoodle.embed.process.distribution.Distribution;
 import de.flapdoodle.embed.process.extract.IExtractedFileSet;
 import de.flapdoodle.embed.process.io.LoggingOutputStreamProcessor;
 import de.flapdoodle.embed.process.io.directories.IDirectory;
-import de.flapdoodle.embed.process.io.progress.LoggingProgressListener;
 import de.flapdoodle.embed.process.runtime.Executable;
 import de.flapdoodle.embed.process.runtime.ProcessControl;
 import org.apache.commons.lang3.ArrayUtils;
-import ru.yandex.qatools.embed.postgresql.config.DownloadConfigBuilder;
 import ru.yandex.qatools.embed.postgresql.config.PostgresConfig;
 import ru.yandex.qatools.embed.postgresql.config.RuntimeConfigBuilder;
-import ru.yandex.qatools.embed.postgresql.ext.ArtifactStoreBuilder;
 import ru.yandex.qatools.embed.postgresql.ext.LogWatchStreamProcessor;
 import ru.yandex.qatools.embed.postgresql.ext.PostgresArtifactStore;
 

--- a/src/main/java/ru/yandex/qatools/embed/postgresql/PostgresProcess.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/PostgresProcess.java
@@ -76,9 +76,7 @@ public class PostgresProcess extends AbstractPGProcess<PostgresExecutable, Postg
 
             IRuntimeConfig runtimeCfg = new RuntimeConfigBuilder().defaults(cmd)
                     .processOutput(new ProcessOutput(logWatch, logWatch, logWatch))
-                    .artifactStore(new ArtifactStoreBuilder().defaults(cmd)
-                            .download(new DownloadConfigBuilder().defaultsForCommand(cmd)
-                                    .progressListener(new LoggingProgressListener(logger, Level.ALL)).build()))
+                    .artifactStore(runtimeConfig.getArtifactStore())
                     .commandLinePostProcessor(runtimeConfig.getCommandLinePostProcessor()).build();
 
             final PostgresConfig postgresConfig = new PostgresConfig(config).withArgs(args);


### PR DESCRIPTION
If user sets custom artifact store the initDb and createDb still use default for command which is wrong.