### PR TITLE
Fix InitDbProcess on Windows

### DIFF
--- a/src/main/java/ru/yandex/qatools/embed/postgresql/InitDbProcess.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/InitDbProcess.java
@@ -23,6 +23,7 @@ package ru.yandex.qatools.embed.postgresql;
 import de.flapdoodle.embed.process.config.IRuntimeConfig;
 import de.flapdoodle.embed.process.config.io.ProcessOutput;
 import de.flapdoodle.embed.process.distribution.Distribution;
+import de.flapdoodle.embed.process.distribution.Platform;
 import de.flapdoodle.embed.process.extract.IExtractedFileSet;
 import de.flapdoodle.embed.process.io.LogWatchStreamProcessor;
 import de.flapdoodle.embed.process.io.Processors;
@@ -66,8 +67,13 @@ class InitDbProcess<E extends InitDbExecutable> extends AbstractPGProcess<E, Ini
                     "--pwfile=" + pwFile.getAbsolutePath()
             ));
         }
+        if (distribution.getPlatform() == Platform.Windows) {
+            ret.addAll(config.getAdditionalInitDbParams());
+        }
         ret.add(config.storage().dbDir().getAbsolutePath());
-        ret.addAll(config.getAdditionalInitDbParams());
+        if (distribution.getPlatform() != Platform.Windows) {
+            ret.addAll(config.getAdditionalInitDbParams());
+        }
         return ret;
     }
 

--- a/src/main/java/ru/yandex/qatools/embed/postgresql/config/AbstractPostgresConfig.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/config/AbstractPostgresConfig.java
@@ -36,16 +36,16 @@ public abstract class AbstractPostgresConfig<C extends AbstractPostgresConfig> e
         this(config, Command.Postgres);
     }
 
-    public AbstractPostgresConfig(IVersion version, Net networt, Storage storage, Timeout timeout, Credentials cred, SupportConfig supportConfig) {
+    public AbstractPostgresConfig(IVersion version, Net network, Storage storage, Timeout timeout, Credentials cred, SupportConfig supportConfig) {
         super(version, supportConfig);
-        this.network = networt;
+        this.network = network;
         this.timeout = timeout;
         this.storage = storage;
         this.credentials = cred;
     }
 
-    public AbstractPostgresConfig(IVersion version, Net networt, Storage storage, Timeout timeout) {
-        this(version, networt, storage, timeout, null, new SupportConfig(Command.Postgres));
+    public AbstractPostgresConfig(IVersion version, Net network, Storage storage, Timeout timeout) {
+        this(version, network, storage, timeout, null, new SupportConfig(Command.Postgres));
     }
 
     public Net net() {

--- a/src/main/java/ru/yandex/qatools/embed/postgresql/config/PostgresConfig.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/config/PostgresConfig.java
@@ -28,12 +28,12 @@ public class PostgresConfig extends AbstractPostgresConfig<PostgresConfig> {
         this(version, new Net(host, port), new Storage(dbName), new Timeout());
     }
 
-    public PostgresConfig(IVersion version, Net networt, Storage storage, Timeout timeout, Credentials cred, Command command) {
-        super(version, networt, storage, timeout, cred, new SupportConfig(command));
+    public PostgresConfig(IVersion version, Net network, Storage storage, Timeout timeout, Credentials cred, Command command) {
+        super(version, network, storage, timeout, cred, new SupportConfig(command));
     }
 
-    public PostgresConfig(IVersion version, Net networt, Storage storage, Timeout timeout, Credentials cred) {
-        this(version, networt, storage, timeout, cred, Command.Postgres);
+    public PostgresConfig(IVersion version, Net network, Storage storage, Timeout timeout, Credentials cred) {
+        this(version, network, storage, timeout, cred, Command.Postgres);
     }
 
     public PostgresConfig(IVersion version, Net network, Storage storage, Timeout timeout) {

--- a/src/main/java/ru/yandex/qatools/embed/postgresql/distribution/Version.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/distribution/Version.java
@@ -6,17 +6,13 @@ import de.flapdoodle.embed.process.distribution.IVersion;
  * PostgreSQL Version enum
  */
 public enum Version implements IVersion {
-
-    V9_6_0("9.6.0-1"),
-    V9_5_0("9.5.0-1"),
-    V9_4_4("9.4.4-1"),
-
-    /**
-     * 9.3.6 release
-     */
-    V9_3_6("9.3.6-1"),
-    @Deprecated
-    V9_2_4("9.2.4-1"),;
+    V9_6_1("9.6.1-1"),
+    V9_5_5("9.5.5-1"),
+    V9_4_10("9.4.10-1"),
+    V9_3_15("9.3.15-1"),
+    @Deprecated V9_2_19("9.2.19-1"),
+    @Deprecated V9_1_24("9.1.24-1"),
+    ;
 
     private final String specificVersion;
 
@@ -34,19 +30,13 @@ public enum Version implements IVersion {
         return "Version{" + specificVersion + '}';
     }
 
-    public static enum Main implements IVersion {
-        @Deprecated
-        V9_2(V9_2_4),
-        /**
-         * latest production release
-         */
-        @Deprecated
-        V9_3(V9_3_6),
-        @Deprecated
-        V9_4(V9_4_4),
-        V9_5(V9_5_0),
-        V9_6(V9_6_0),
-
+    public enum Main implements IVersion {
+        @Deprecated V9_1(V9_1_24),
+        @Deprecated V9_2(V9_2_19),
+        V9_3(V9_3_15),
+        V9_4(V9_4_10),
+        V9_5(V9_5_5),
+        V9_6(V9_6_1),
         PRODUCTION(V9_6);
 
         private final IVersion _latest;

--- a/src/test/java/ru/yandex/qatools/embed/postgresql/TestPostgresWithPgCtl.java
+++ b/src/test/java/ru/yandex/qatools/embed/postgresql/TestPostgresWithPgCtl.java
@@ -30,7 +30,7 @@ public class TestPostgresWithPgCtl {
     public void setUp() throws Exception {
         PostgresStarter<PostgresExecutable, PostgresProcess> runtime = PostgresStarter.getInstance(
                 new RuntimeConfigBuilder().defaults(Command.PgCtl).build());
-        final PostgresConfig config = new PostgresConfig(Version.V9_4_4, new AbstractPostgresConfig.Net(
+        final PostgresConfig config = new PostgresConfig(Version.Main.PRODUCTION, new AbstractPostgresConfig.Net(
                 "localhost", findFreePort()
         ), new AbstractPostgresConfig.Storage("test"), new AbstractPostgresConfig.Timeout(),
                 new AbstractPostgresConfig.Credentials("user", "password"), Command.PgCtl);


### PR DESCRIPTION
Windows does not support trailing parameters after the storage parameter;
reorder additional parameters specifically for that platform

Bump distributions to latest available on EnterpriseDB

Fix typo networt => network