### PR TITLE
Mark the process has "ready to accept connections"

### DIFF
--- a/src/main/java/ru/yandex/qatools/embed/postgresql/PostgresProcess.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/PostgresProcess.java
@@ -255,6 +255,7 @@ public class PostgresProcess extends AbstractPGProcess<PostgresExecutable, Postg
                     new HashSet<>(singleton("database creation failed")), 3000, getConfig().storage().dbName());
             try {
                 if (isEmpty(output) || !output.contains("could not connect to database")) {
+                    this.processReady = true;
                     break;
                 }
                 LOGGER.warn("Could not create database first time ({} of {} trials)", trial, MAX_CREATEDB_TRIALS);


### PR DESCRIPTION
The flag "processReady" cannot be used because it is never set.

This PR try to fix this issue

Hope it helps
M.