### PR TITLE
Add support for Postgresql 10.0 and 9.6.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ postgres.start(cachedRuntimeConfig("C:\\Users\\vasya\\pgembedded-installation"))
   
 ### Supported Versions
 
-Versions: 9.6.2, 9.5.5, 9.4.10, any custom
+Versions: 10.0, 9.6.5, 9.5.7, any custom
 
 Platforms: Linux, Windows and MacOSX supported
 

--- a/src/main/java/ru/yandex/qatools/embed/postgresql/distribution/Version.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/distribution/Version.java
@@ -6,7 +6,7 @@ import de.flapdoodle.embed.process.distribution.IVersion;
  * PostgreSQL Version enum
  */
 public enum Version implements IVersion {
-    V9_6_3("9.6.3-1"),
+    V9_6_5("9.6.5-1"),
     @Deprecated V9_5_7("9.5.7-1"),;
 
     private final String specificVersion;
@@ -27,7 +27,7 @@ public enum Version implements IVersion {
 
     public enum Main implements IVersion {
         V9_5(V9_5_7),
-        V9_6(V9_6_3),
+        V9_6(V9_6_5),
         PRODUCTION(V9_6);
 
         private final IVersion _latest;

--- a/src/main/java/ru/yandex/qatools/embed/postgresql/distribution/Version.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/distribution/Version.java
@@ -6,6 +6,7 @@ import de.flapdoodle.embed.process.distribution.IVersion;
  * PostgreSQL Version enum
  */
 public enum Version implements IVersion {
+    V10_0("10.0-1"),
     V9_6_5("9.6.5-1"),
     @Deprecated V9_5_7("9.5.7-1"),;
 
@@ -28,7 +29,8 @@ public enum Version implements IVersion {
     public enum Main implements IVersion {
         V9_5(V9_5_7),
         V9_6(V9_6_5),
-        PRODUCTION(V9_6);
+        V10(V10_0),
+        PRODUCTION(V10_0);
 
         private final IVersion _latest;
 

--- a/src/test/java/ru/yandex/qatools/embed/postgresql/TestMultipleInstance.java
+++ b/src/test/java/ru/yandex/qatools/embed/postgresql/TestMultipleInstance.java
@@ -17,13 +17,13 @@ public class TestMultipleInstance {
         final EmbeddedPostgres postgres0 = new EmbeddedPostgres();
         postgres0.start();
         assertThat(postgres0.getConnectionUrl().isPresent(), is(true));
-        checkVersion(postgres0.getConnectionUrl().get(), "PostgreSQL 9.6");
+        checkVersion(postgres0.getConnectionUrl().get(), "PostgreSQL 10.0");
         postgres0.stop();
 
-        final EmbeddedPostgres postgres1 = new EmbeddedPostgres(Version.Main.V9_5);
+        final EmbeddedPostgres postgres1 = new EmbeddedPostgres(Version.Main.V9_6);
         postgres1.start();
         assertThat(postgres1.getConnectionUrl().isPresent(), is(true));
-        checkVersion(postgres1.getConnectionUrl().get(), "PostgreSQL 9.5");
+        checkVersion(postgres1.getConnectionUrl().get(), "PostgreSQL 9.6");
         postgres1.stop();
     }
 
@@ -37,8 +37,8 @@ public class TestMultipleInstance {
         postgres1.start();
         assertThat(postgres1.getConnectionUrl().isPresent(), is(true));
 
-        checkVersion(postgres0.getConnectionUrl().get(), "PostgreSQL 9.6");
-        checkVersion(postgres1.getConnectionUrl().get(), "PostgreSQL 9.6");
+        checkVersion(postgres0.getConnectionUrl().get(), "PostgreSQL 10.0");
+        checkVersion(postgres1.getConnectionUrl().get(), "PostgreSQL 10.0");
 
         postgres0.stop();
         postgres1.stop();
@@ -46,16 +46,16 @@ public class TestMultipleInstance {
 
     @Test
     public void itShouldAllowToRunTwoInstancesAtSameTimeAndWithDifferentVersions() throws Exception {
-        final EmbeddedPostgres postgres0 = new EmbeddedPostgres(Version.Main.V9_5);
+        final EmbeddedPostgres postgres0 = new EmbeddedPostgres(Version.Main.V9_6);
         postgres0.start();
         assertThat(postgres0.getConnectionUrl().isPresent(), is(true));
 
-        final EmbeddedPostgres postgres1 = new EmbeddedPostgres(Version.Main.V9_6);
+        final EmbeddedPostgres postgres1 = new EmbeddedPostgres(Version.Main.V10);
         postgres1.start();
         assertThat(postgres1.getConnectionUrl().isPresent(), is(true));
 
-        checkVersion(postgres0.getConnectionUrl().get(), "PostgreSQL 9.5");
-        checkVersion(postgres1.getConnectionUrl().get(), "PostgreSQL 9.6");
+        checkVersion(postgres0.getConnectionUrl().get(), "PostgreSQL 9.6");
+        checkVersion(postgres1.getConnectionUrl().get(), "PostgreSQL 10.0");
 
         postgres0.stop();
         postgres1.stop();


### PR DESCRIPTION
Earlier this month, Postgresql 10.0 was released. This change adds support for it in `postgresql-embedded`.

Also I have updated the 9.6 version to 9.6.5 which seems to be the latest at this moment.

I wasn't sure if `PRODUCTION` should be updated at this stage or not. Let me know what you think.

Some more information:
- https://wiki.postgresql.org/wiki/New_in_postgres_10
- https://www.postgresql.org/about/news/1786/
- https://www.postgresql.org/docs/10/static/release-10.html