### PR TITLE
Security update 10.1, 9.6.6, 9.5.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ Add the following dependency to your pom.xml:
 <dependency>
     <groupId>ru.yandex.qatools.embed</groupId>
     <artifactId>postgresql-embedded</artifactId>
-    <version>2.5</version>
+    <version>2.6</version>
 </dependency>
 ```
 ### Gradle
 
 Add a line to build.gradle:
 ```groovy
-compile 'ru.yandex.qatools.embed:postgresql-embedded:2.5'
+compile 'ru.yandex.qatools.embed:postgresql-embedded:2.6'
 ```
 
 ## Howto
@@ -115,7 +115,7 @@ postgres.start(cachedRuntimeConfig("C:\\Users\\vasya\\pgembedded-installation"))
   
 ### Supported Versions
 
-Versions: 10.0, 9.6.5, 9.5.7, any custom
+Versions: 10.1, 9.6.6, 9.5.10, any custom
 
 Platforms: Linux, Windows and MacOSX supported
 

--- a/src/main/java/ru/yandex/qatools/embed/postgresql/PackagePaths.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/PackagePaths.java
@@ -140,6 +140,18 @@ public class PackagePaths implements IPackageResolver {
                 throw new IllegalArgumentException("Unknown BitSize " + distribution.getBitsize());
         }
 
-        return "postgresql-" + sversion + "-" + splatform + bitsize + "-binaries" + "." + sarchiveType;
+        String path = "postgresql-" + sversion + "-" + splatform + bitsize + "-binaries" + "." + sarchiveType;
+        switch (path) {
+            case       "postgresql-10.1-1-windows-x64-binaries.zip":
+                path = "postgresql-10.1-2-windows-x64-binaries.zip";
+                break;
+            case       "postgresql-9.6.6-1-windows-x64-binaries.zip":
+                path = "postgresql-9.6.6-2-windows-x64-binaries.zip";
+                break;
+            default:
+                // no path change needed
+                break;
+        }
+        return path;
     }
 }

--- a/src/main/java/ru/yandex/qatools/embed/postgresql/distribution/Version.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/distribution/Version.java
@@ -6,9 +6,9 @@ import de.flapdoodle.embed.process.distribution.IVersion;
  * PostgreSQL Version enum
  */
 public enum Version implements IVersion {
-    V10_0("10.0-1"),
-    V9_6_5("9.6.5-1"),
-    @Deprecated V9_5_7("9.5.7-1"),;
+    V10_1("10.1-1"),
+    V9_6_6("9.6.6-1"),
+    @Deprecated V9_5_10("9.5.10-1"),;
 
     private final String specificVersion;
 
@@ -27,10 +27,10 @@ public enum Version implements IVersion {
     }
 
     public enum Main implements IVersion {
-        V9_5(V9_5_7),
-        V9_6(V9_6_5),
-        V10(V10_0),
-        PRODUCTION(V10_0);
+        V9_5(V9_5_10),
+        V9_6(V9_6_6),
+        V10(V10_1),
+        PRODUCTION(V10_1);
 
         private final IVersion _latest;
 

--- a/src/test/java/ru/yandex/qatools/embed/postgresql/TestMultipleInstance.java
+++ b/src/test/java/ru/yandex/qatools/embed/postgresql/TestMultipleInstance.java
@@ -17,7 +17,7 @@ public class TestMultipleInstance {
         final EmbeddedPostgres postgres0 = new EmbeddedPostgres();
         postgres0.start();
         assertThat(postgres0.getConnectionUrl().isPresent(), is(true));
-        checkVersion(postgres0.getConnectionUrl().get(), "PostgreSQL 10.0");
+        checkVersion(postgres0.getConnectionUrl().get(), "PostgreSQL 10.1");
         postgres0.stop();
 
         final EmbeddedPostgres postgres1 = new EmbeddedPostgres(Version.Main.V9_6);
@@ -37,8 +37,8 @@ public class TestMultipleInstance {
         postgres1.start();
         assertThat(postgres1.getConnectionUrl().isPresent(), is(true));
 
-        checkVersion(postgres0.getConnectionUrl().get(), "PostgreSQL 10.0");
-        checkVersion(postgres1.getConnectionUrl().get(), "PostgreSQL 10.0");
+        checkVersion(postgres0.getConnectionUrl().get(), "PostgreSQL 10.1");
+        checkVersion(postgres1.getConnectionUrl().get(), "PostgreSQL 10.1");
 
         postgres0.stop();
         postgres1.stop();
@@ -55,7 +55,7 @@ public class TestMultipleInstance {
         assertThat(postgres1.getConnectionUrl().isPresent(), is(true));
 
         checkVersion(postgres0.getConnectionUrl().get(), "PostgreSQL 9.6");
-        checkVersion(postgres1.getConnectionUrl().get(), "PostgreSQL 10.0");
+        checkVersion(postgres1.getConnectionUrl().get(), "PostgreSQL 10.1");
 
         postgres0.stop();
         postgres1.stop();


### PR DESCRIPTION
Three security vulnerabilities have been fixed by PostgreSQL 10.1, 9.6.6, 9.5.10:

* CVE-2017-12172: Start scripts permit database administrator to modify root-owned files
* CVE-2017-15098: Memory disclosure in JSON functions
* CVE-2017-15099: INSERT ... ON CONFLICT DO UPDATE fails to enforce SELECT privileges

This PostgreSQL update also fixes a number of bugs reported in the last few months.

https://www.postgresql.org/about/news/1801/