### PR TITLE
Security update 10.2, 9.6.7, 9.5.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ Add the following dependency to your pom.xml:
 <dependency>
     <groupId>ru.yandex.qatools.embed</groupId>
     <artifactId>postgresql-embedded</artifactId>
-    <version>2.6</version>
+    <version>2.7</version>
 </dependency>
 ```
 ### Gradle
 
 Add a line to build.gradle:
 ```groovy
-compile 'ru.yandex.qatools.embed:postgresql-embedded:2.6'
+compile 'ru.yandex.qatools.embed:postgresql-embedded:2.7'
 ```
 
 ## Howto
@@ -115,7 +115,7 @@ postgres.start(cachedRuntimeConfig("C:\\Users\\vasya\\pgembedded-installation"))
   
 ### Supported Versions
 
-Versions: 10.1, 9.6.6, 9.5.10, any custom
+Versions: 10.2, 9.6.7, 9.5.11, any custom
 
 Platforms: Linux, Windows and MacOSX supported
 

--- a/src/main/java/ru/yandex/qatools/embed/postgresql/distribution/Version.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/distribution/Version.java
@@ -6,9 +6,9 @@ import de.flapdoodle.embed.process.distribution.IVersion;
  * PostgreSQL Version enum
  */
 public enum Version implements IVersion {
-    V10_1("10.1-1"),
-    V9_6_6("9.6.6-1"),
-    @Deprecated V9_5_10("9.5.10-1"),;
+    V10_2("10.2-1"),
+    V9_6_7("9.6.7-1"),
+    @Deprecated V9_5_11("9.5.11-1"),;
 
     private final String specificVersion;
 
@@ -27,10 +27,10 @@ public enum Version implements IVersion {
     }
 
     public enum Main implements IVersion {
-        V9_5(V9_5_10),
-        V9_6(V9_6_6),
-        V10(V10_1),
-        PRODUCTION(V10_1);
+        V9_5(V9_5_11),
+        V9_6(V9_6_7),
+        V10(V10_2),
+        PRODUCTION(V10_2);
 
         private final IVersion _latest;
 

--- a/src/test/java/ru/yandex/qatools/embed/postgresql/TestMultipleInstance.java
+++ b/src/test/java/ru/yandex/qatools/embed/postgresql/TestMultipleInstance.java
@@ -17,7 +17,7 @@ public class TestMultipleInstance {
         final EmbeddedPostgres postgres0 = new EmbeddedPostgres();
         postgres0.start();
         assertThat(postgres0.getConnectionUrl().isPresent(), is(true));
-        checkVersion(postgres0.getConnectionUrl().get(), "PostgreSQL 10.1");
+        checkVersion(postgres0.getConnectionUrl().get(), "PostgreSQL 10.2");
         postgres0.stop();
 
         final EmbeddedPostgres postgres1 = new EmbeddedPostgres(Version.Main.V9_6);
@@ -37,8 +37,8 @@ public class TestMultipleInstance {
         postgres1.start();
         assertThat(postgres1.getConnectionUrl().isPresent(), is(true));
 
-        checkVersion(postgres0.getConnectionUrl().get(), "PostgreSQL 10.1");
-        checkVersion(postgres1.getConnectionUrl().get(), "PostgreSQL 10.1");
+        checkVersion(postgres0.getConnectionUrl().get(), "PostgreSQL 10.2");
+        checkVersion(postgres1.getConnectionUrl().get(), "PostgreSQL 10.2");
 
         postgres0.stop();
         postgres1.stop();
@@ -55,7 +55,7 @@ public class TestMultipleInstance {
         assertThat(postgres1.getConnectionUrl().isPresent(), is(true));
 
         checkVersion(postgres0.getConnectionUrl().get(), "PostgreSQL 9.6");
-        checkVersion(postgres1.getConnectionUrl().get(), "PostgreSQL 10.1");
+        checkVersion(postgres1.getConnectionUrl().get(), "PostgreSQL 10.2");
 
         postgres0.stop();
         postgres1.stop();


### PR DESCRIPTION
Two security vulnerabilities have been fixed by PostgreSQL 10.2, 9.6.7, 9.5.11:

* CVE-2018-1052: Fix the processing of partition keys containing multiple expressions
* CVE-2018-1053: Ensure that all temporary files made with "pg_upgrade" are non-world-readable

This PostgreSQL update also fixes over 60 bugs.

https://www.postgresql.org/about/news/1829/