### PR TITLE
Fix pg_ctl Postgres startup command line generation

### DIFF
--- a/src/main/java/ru/yandex/qatools/embed/postgresql/PgCtlProcess.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/PgCtlProcess.java
@@ -28,7 +28,7 @@ class PgCtlProcess<E extends PgCtlExecutable> extends AbstractPGProcess<E, PgCtl
         ret.addAll(asList(exe.executable().getAbsolutePath()));
         ret.addAll(asList(
                 "-o",
-                String.format("\"-p %s -h %s\"", config.net().port(), config.net().host()),
+                String.format("-p %s -h %s", config.net().port(), config.net().host()),
                 "-D", config.storage().dbDir().getAbsolutePath(),
                 "-w"
         ));

--- a/src/main/java/ru/yandex/qatools/embed/postgresql/PostgresProcess.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/PostgresProcess.java
@@ -210,7 +210,8 @@ public class PostgresProcess extends AbstractPGProcess<PostgresExecutable, Postg
                 break;
             case "pg_ctl": //NOSONAR
                 ret.addAll(asList(exe.executable().getAbsolutePath(),
-                        String.format("-o \"-p %s\" \"-h %s\"", config.net().port(), config.net().host()),
+                        "-o",
+                        String.format("-p %s -h %s", config.net().port(), config.net().host()),
                         "-D", config.storage().dbDir().getAbsolutePath(),
                         "-w",
                         "start"

--- a/src/test/java/ru/yandex/qatools/embed/postgresql/TestPostgresWithPgCtl.java
+++ b/src/test/java/ru/yandex/qatools/embed/postgresql/TestPostgresWithPgCtl.java
@@ -22,7 +22,6 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static ru.yandex.qatools.embed.postgresql.util.SocketUtil.findFreePort;
 
-@Ignore
 public class TestPostgresWithPgCtl {
 
     private PostgresProcess process;


### PR DESCRIPTION
-o and its parameter should be separate arguments

This another way to close #115.