### PR TITLE
Security update 10.5, 9.6.10, 9.5.14 - CVE-2018-10915, CVE-2018-10925

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ postgres.start(cachedRuntimeConfig("C:\\Users\\vasya\\pgembedded-installation"))
   
 ### Supported Versions
 
-Versions: 10.4, 9.6.9, 9.5.13, any custom
+Versions: 10.5, 9.6.10, 9.5.14, any custom
 
 Platforms: Linux, Windows and MacOSX supported
 

--- a/src/main/java/ru/yandex/qatools/embed/postgresql/distribution/Version.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/distribution/Version.java
@@ -6,9 +6,9 @@ import de.flapdoodle.embed.process.distribution.IVersion;
  * PostgreSQL Version enum
  */
 public enum Version implements IVersion {
-    V10_4("10.4-1"),
-    V9_6_9("9.6.9-1"),
-    @Deprecated V9_5_13("9.5.13-1"),;
+    V10_5("10.5-1"),
+    V9_6_10("9.6.10-1"),
+    @Deprecated V9_5_14("9.5.14-1"),;
 
     private final String specificVersion;
 
@@ -27,10 +27,10 @@ public enum Version implements IVersion {
     }
 
     public enum Main implements IVersion {
-        V9_5(V9_5_13),
-        V9_6(V9_6_9),
-        V10(V10_4),
-        PRODUCTION(V10_4);
+        V9_5(V9_5_14),
+        V9_6(V9_6_10),
+        V10(V10_5),
+        PRODUCTION(V10_5);
 
         private final IVersion _latest;
 

--- a/src/test/java/ru/yandex/qatools/embed/postgresql/TestMultipleInstance.java
+++ b/src/test/java/ru/yandex/qatools/embed/postgresql/TestMultipleInstance.java
@@ -15,30 +15,26 @@ public class TestMultipleInstance {
     @Test
     public void itShouldAllowToRunTwoInstancesWithDifferentVersions() throws Exception {
         final EmbeddedPostgres postgres0 = new EmbeddedPostgres();
-        postgres0.start();
-        assertThat(postgres0.getConnectionUrl().isPresent(), is(true));
-        checkVersion(postgres0.getConnectionUrl().get(), "PostgreSQL 10.4");
+        start(postgres0);
+        checkVersion(postgres0, "PostgreSQL 10.");
         postgres0.stop();
 
         final EmbeddedPostgres postgres1 = new EmbeddedPostgres(Version.Main.V9_6);
-        postgres1.start();
-        assertThat(postgres1.getConnectionUrl().isPresent(), is(true));
-        checkVersion(postgres1.getConnectionUrl().get(), "PostgreSQL 9.6");
+        start(postgres1);
+        checkVersion(postgres1, "PostgreSQL 9.6");
         postgres1.stop();
     }
 
     @Test
     public void itShouldAllowToRunTwoInstancesAtSameTime() throws Exception {
         final EmbeddedPostgres postgres0 = new EmbeddedPostgres();
-        postgres0.start();
-        assertThat(postgres0.getConnectionUrl().isPresent(), is(true));
+        start(postgres0);
 
         final EmbeddedPostgres postgres1 = new EmbeddedPostgres();
-        postgres1.start();
-        assertThat(postgres1.getConnectionUrl().isPresent(), is(true));
+        start(postgres1);
 
-        checkVersion(postgres0.getConnectionUrl().get(), "PostgreSQL 10.4");
-        checkVersion(postgres1.getConnectionUrl().get(), "PostgreSQL 10.4");
+        checkVersion(postgres0, "PostgreSQL 10.");
+        checkVersion(postgres1, "PostgreSQL 10.");
 
         postgres0.stop();
         postgres1.stop();
@@ -47,21 +43,25 @@ public class TestMultipleInstance {
     @Test
     public void itShouldAllowToRunTwoInstancesAtSameTimeAndWithDifferentVersions() throws Exception {
         final EmbeddedPostgres postgres0 = new EmbeddedPostgres(Version.Main.V9_6);
-        postgres0.start();
-        assertThat(postgres0.getConnectionUrl().isPresent(), is(true));
+        start(postgres0);
 
         final EmbeddedPostgres postgres1 = new EmbeddedPostgres(Version.Main.V10);
-        postgres1.start();
-        assertThat(postgres1.getConnectionUrl().isPresent(), is(true));
+        start(postgres1);
 
-        checkVersion(postgres0.getConnectionUrl().get(), "PostgreSQL 9.6");
-        checkVersion(postgres1.getConnectionUrl().get(), "PostgreSQL 10.4");
+        checkVersion(postgres0, "PostgreSQL 9.6");
+        checkVersion(postgres1, "PostgreSQL 10.");
 
         postgres0.stop();
         postgres1.stop();
     }
 
-    private void checkVersion(String jdbcUrl, String expectedVersion) throws Exception {
+    private void start(EmbeddedPostgres postgres) throws Exception {
+        postgres.start();
+        assertThat(postgres.getConnectionUrl().isPresent(), is(true));
+    }
+
+    private void checkVersion(EmbeddedPostgres postgres, String expectedVersion) throws Exception {
+        String jdbcUrl = postgres.getConnectionUrl().get();
         try (final Connection conn = DriverManager.getConnection(jdbcUrl);
              final Statement statement = conn.createStatement()) {
             assertThat(statement.execute("SELECT version();"), is(true));


### PR DESCRIPTION
This PostgreSQL release fixes two security issues as well as bugs reported over the last three months.

* CVE-2018-10915: Certain host connection parameters defeat client-side security defenses
* CVE-2018-10925: Memory disclosure and missing authorization in INSERT ... ON CONFLICT DO UPDATE

Full PostgreSQL release note: https://www.postgresql.org/about/news/1878/