### PR TITLE
Security update 11.1, 10.6, 9.6.11, 9.5.15 - CVE-2018-16850

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ postgres.start(cachedRuntimeConfig("C:\\Users\\vasya\\pgembedded-installation"))
   
 ### Supported Versions
 
-Versions: 10.5, 9.6.10, 9.5.14, any custom
-
-Platforms: Linux, Windows and MacOSX supported
-
+* 11.1: on Mac OS X and Windows 64 bit
+* 10.6, 9.6.11, 9.5.15: on Linux, Windows, Mac OS X
+* any custom version

--- a/src/main/java/ru/yandex/qatools/embed/postgresql/distribution/Version.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/distribution/Version.java
@@ -6,9 +6,16 @@ import de.flapdoodle.embed.process.distribution.IVersion;
  * PostgreSQL Version enum
  */
 public enum Version implements IVersion {
-    V10_5("10.5-1"),
-    V9_6_10("9.6.10-1"),
-    @Deprecated V9_5_14("9.5.14-1"),;
+    /**
+     * 11 for Mac OS X and Windows x86-64 only because EnterpriseDB reduced the
+     * <a href="https://www.enterprisedb.com/docs/en/11.0/PG_Inst_Guide_v11/PostgreSQL_Installation_Guide.1.04.html">supported platforms</a>
+     * on their
+     * <a href="https://www.enterprisedb.com/downloads/postgres-postgresql-downloads">binary download site</a>.
+     */
+    V11_1("11.1-1"),
+    V10_6("10.6-1"),
+    V9_6_11("9.6.11-1"),
+    @Deprecated V9_5_15("9.5.15-1"),;
 
     private final String specificVersion;
 
@@ -27,10 +34,17 @@ public enum Version implements IVersion {
     }
 
     public enum Main implements IVersion {
-        V9_5(V9_5_14),
-        V9_6(V9_6_10),
-        V10(V10_5),
-        PRODUCTION(V10_5);
+        @Deprecated V9_5(V9_5_15),
+        V9_6(V9_6_11),
+        V10(V10_6),
+        PRODUCTION(V10_6),
+        /**
+         * 11 for Mac OS X and Windows x86-64 only because EnterpriseDB reduced the
+         * <a href="https://www.enterprisedb.com/docs/en/11.0/PG_Inst_Guide_v11/PostgreSQL_Installation_Guide.1.04.html">supported platforms</a>
+         * on their
+         * <a href="https://www.enterprisedb.com/downloads/postgres-postgresql-downloads">binary download site</a>.
+         */
+        V11(V11_1);
 
         private final IVersion _latest;
 

--- a/src/test/java/ru/yandex/qatools/embed/postgresql/TestDownloads.java
+++ b/src/test/java/ru/yandex/qatools/embed/postgresql/TestDownloads.java
@@ -17,6 +17,21 @@ import static org.junit.Assert.assertThat;
 
 public class TestDownloads {
 
+    /** Version 11 binary downloads are av^ailable for OS X and Windows 64 bit only */
+    private boolean supported(Distribution distribution) {
+        if (! distribution.getVersion().asInDownloadPath().startsWith("11.")) {
+            return true;
+        }
+        switch (distribution.getPlatform()) {
+        case OS_X:
+            return true;
+        case Windows:
+            return distribution.getBitsize() == BitSize.B64;
+        default:
+            return false;
+        }
+    }
+
     @Test
     public void testDownloads() throws IOException {
         IArtifactStore artifactStore = new PostgresArtifactStoreBuilder().defaults(Command.Postgres).build();
@@ -25,6 +40,9 @@ public class TestDownloads {
             for (BitSize b : BitSize.values()) {
                 for (IVersion version : Version.Main.values()) {
                     Distribution distribution = new Distribution(version, p, b);
+                    if (! supported(distribution)) {
+                        continue;
+                    }
                     assertThat("Distribution: " + distribution + " should be accessible", artifactStore.checkDistribution(distribution), is(true));
                 }
             }

--- a/src/test/java/ru/yandex/qatools/embed/postgresql/TestDownloads.java
+++ b/src/test/java/ru/yandex/qatools/embed/postgresql/TestDownloads.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertThat;
 
 public class TestDownloads {
 
-    /** Version 11 binary downloads are av^ailable for OS X and Windows 64 bit only */
+    /** Version 11 binary downloads are available for OS X and Windows 64 bit only */
     private boolean supported(Distribution distribution) {
         if (! distribution.getVersion().asInDownloadPath().startsWith("11.")) {
             return true;


### PR DESCRIPTION
This release fixes one security issue as well as several bugs reported over the last three months.

* CVE-2018-16850: SQL injection in pg_upgrade and pg_dump, via CREATE TRIGGER ... REFERENCING.

Full release note: https://www.postgresql.org/about/news/1905/