### PR TITLE
Use up to date process embed version to be compatible with Java 9+.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,12 @@
         <dependency>
             <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.process</artifactId>
-            <version>2.0.2</version>
+            <version>2.0.5</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.4</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/ru/yandex/qatools/embed/postgresql/config/SupportConfig.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/config/SupportConfig.java
@@ -24,4 +24,9 @@ public class SupportConfig implements ISupportConfig {
     public String messageOnException(Class<?> context, Exception exception) {
         return null;
     }
+
+    @Override
+    public long maxStopTimeoutMillis() {
+        return 100;
+    }
 }


### PR DESCRIPTION
Also, add commons-io dependency -- it used to be a transitive dependency
from the old version of process embed, but it's used directly.