### PR TITLE
Fix #160, Upgrade PgSQL version

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,6 @@ postgres.start(cachedRuntimeConfig("C:\\Users\\vasya\\pgembedded-installation"))
   
 ### Supported Versions
 
-* 11.1: on Mac OS X and Windows 64 bit
-* 10.6, 9.6.11, 9.5.15: on Linux, Windows, Mac OS X
+* 11.2: on Mac OS X and Windows 64 bit
+* 10.7, 9.6.12, 9.5.16: on Linux, Windows, Mac OS X
 * any custom version

--- a/src/main/java/ru/yandex/qatools/embed/postgresql/distribution/Version.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/distribution/Version.java
@@ -12,10 +12,10 @@ public enum Version implements IVersion {
      * on their
      * <a href="https://www.enterprisedb.com/downloads/postgres-postgresql-downloads">binary download site</a>.
      */
-    V11_1("11.1-1"),
-    V10_6("10.6-1"),
-    V9_6_11("9.6.11-1"),
-    @Deprecated V9_5_15("9.5.15-1"),;
+    V11_2("11.2-1"),
+    V10_7("10.7-1"),
+    V9_6_12("9.6.12-1"),
+    @Deprecated V9_5_16("9.5.16-1"),;
 
     private final String specificVersion;
 
@@ -34,17 +34,17 @@ public enum Version implements IVersion {
     }
 
     public enum Main implements IVersion {
-        @Deprecated V9_5(V9_5_15),
-        V9_6(V9_6_11),
-        V10(V10_6),
-        PRODUCTION(V10_6),
+        @Deprecated V9_5(V9_5_16),
+        V9_6(V9_6_12),
+        V10(V10_7),
+        PRODUCTION(V10_7),
         /**
          * 11 for Mac OS X and Windows x86-64 only because EnterpriseDB reduced the
          * <a href="https://www.enterprisedb.com/docs/en/11.0/PG_Inst_Guide_v11/PostgreSQL_Installation_Guide.1.04.html">supported platforms</a>
          * on their
          * <a href="https://www.enterprisedb.com/downloads/postgres-postgresql-downloads">binary download site</a>.
          */
-        V11(V11_1);
+        V11(V11_2);
 
         private final IVersion _latest;
 


### PR DESCRIPTION
Team,

This pull request upgrades PgSql version to current Feb 14, 2019 release train. https://www.postgresql.org/about/news/1920/

Resolves issue #160 performance and bugfix release