### PR TITLE
Support exporting dumps with custom user-defined CLI args

### DIFF
--- a/src/main/java/ru/yandex/qatools/embed/postgresql/PostgresProcess.java
+++ b/src/main/java/ru/yandex/qatools/embed/postgresql/PostgresProcess.java
@@ -335,35 +335,80 @@ public class PostgresProcess extends AbstractPGProcess<PostgresExecutable, Postg
     }
 
     public void exportToFile(File file) {
-        runCmd(getConfig(), runtimeConfig, PgDump, "", new HashSet<>(singletonList("export from " + getConfig().storage().dbName() + " failed")),
-                "-U", getConfig().credentials().username(),
-                "-d", getConfig().storage().dbName(),
-                "-h", getConfig().net().host(),
-                "-p", String.valueOf(getConfig().net().port()),
-                "-f", file.getAbsolutePath()
-        );
+        exportToFileWithArgs(file);
+    }
+
+    /**
+     * Export database (scheme + data) to file, using the additional arguments in the {@code pg_dump} command-line
+     * @param file the resulting file
+     * @param cliArgs additional arguments for {@code pg_dump} (be sure to separate args from their values)
+     */
+    public void exportToFileWithArgs(File file, String... cliArgs) {
+        String[] args = {
+            "-U", getConfig().credentials().username(),
+            "-d", getConfig().storage().dbName(),
+            "-h", getConfig().net().host(),
+            "-p", String.valueOf(getConfig().net().port()),
+            "-f", file.getAbsolutePath()
+        };
+        if (cliArgs != null && cliArgs.length != 0) {
+            args = ArrayUtils.addAll(args, cliArgs);
+        }
+        runCmd(getConfig(), runtimeConfig, PgDump, "",
+            new HashSet<>(singletonList("export from " + getConfig().storage().dbName() + " failed")),
+            args);
     }
 
     public void exportSchemeToFile(File file) {
-        runCmd(getConfig(), runtimeConfig, PgDump, "", new HashSet<>(singletonList("export from " + getConfig().storage().dbName() + " failed")),
-                "-U", getConfig().credentials().username(),
-                "-d", getConfig().storage().dbName(),
-                "-h", getConfig().net().host(),
-                "-p", String.valueOf(getConfig().net().port()),
-                "-f", file.getAbsolutePath(),
-                "-s"
-        );
+        exportSchemeToFileWithArgs(file);
+    }
+
+    /**
+     * Export database scheme to file, using the additional arguments in the {@code pg_dump} command-line
+     * @param file the resulting file
+     * @param cliArgs additional arguments for {@code pg_dump} (be sure to separate args from their values)
+     */
+    public void exportSchemeToFileWithArgs(File file, String... cliArgs) {
+        String[] args = {
+            "-U", getConfig().credentials().username(),
+            "-d", getConfig().storage().dbName(),
+            "-h", getConfig().net().host(),
+            "-p", String.valueOf(getConfig().net().port()),
+            "-f", file.getAbsolutePath(),
+            "-s"
+        };
+        if (cliArgs != null && cliArgs.length != 0) {
+            args = ArrayUtils.addAll(args, cliArgs);
+        }
+        runCmd(getConfig(), runtimeConfig, PgDump, "",
+            new HashSet<>(singletonList("export from " + getConfig().storage().dbName() + " failed")),
+            args);
     }
 
     public void exportDataToFile(File file) {
-        runCmd(getConfig(), runtimeConfig, PgDump, "", new HashSet<>(singletonList("export from " + getConfig().storage().dbName() + " failed")),
-                "-U", getConfig().credentials().username(),
-                "-d", getConfig().storage().dbName(),
-                "-h", getConfig().net().host(),
-                "-p", String.valueOf(getConfig().net().port()),
-                "-f", file.getAbsolutePath(),
-                "-a"
-        );
+        exportDataToFileWithArgs(file);
+    }
+
+    /**
+     * Export database data to file, using the additional arguments in the {@code pg_dump} command-line
+     * @param file the resulting file
+     * @param cliArgs additional arguments for {@code pg_dump} (be sure to separate args from their values)
+     */
+    public void exportDataToFileWithArgs(File file, String... cliArgs) {
+        String[] args = {
+            "-U", getConfig().credentials().username(),
+            "-d", getConfig().storage().dbName(),
+            "-h", getConfig().net().host(),
+            "-p", String.valueOf(getConfig().net().port()),
+            "-f", file.getAbsolutePath(),
+            "-a"
+        };
+        if (cliArgs != null && cliArgs.length != 0) {
+            args = ArrayUtils.addAll(args, cliArgs);
+        }
+        runCmd(getConfig(), runtimeConfig, PgDump, "",
+            new HashSet<>(singletonList("export from " + getConfig().storage().dbName() + " failed")),
+            args);
     }
 
     public boolean isProcessReady() {

--- a/src/test/java/ru/yandex/qatools/embed/postgresql/AbstractPsqlTest.java
+++ b/src/test/java/ru/yandex/qatools/embed/postgresql/AbstractPsqlTest.java
@@ -1,5 +1,12 @@
 package ru.yandex.qatools.embed.postgresql;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import org.junit.After;
 import org.junit.Before;
 import ru.yandex.qatools.embed.postgresql.config.AbstractPostgresConfig;
@@ -49,6 +56,39 @@ public abstract class AbstractPsqlTest {
     public void tearDown() throws Exception {
         conn.close();
         process.stop();
+    }
+
+    /**
+     * Delete a given directory, recursively
+     * @param path the directory path to delete
+     * @throws IOException
+     */
+    static void deleteDir(final Path path) throws IOException {
+        Files.walkFileTree(
+            path,
+            new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes basicFileAttributes)
+                    throws IOException {
+                    Files.delete(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException e) throws IOException {
+                    Files.delete(dir);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+    }
+
+    /**
+     * Delete a given directory, recursively
+     * @param file the directory to delete
+     * @throws IOException
+     */
+    static void deleteDir(final File file) throws IOException {
+        deleteDir(file.toPath());
     }
 
 }

--- a/src/test/java/ru/yandex/qatools/embed/postgresql/TestPsqlExport.java
+++ b/src/test/java/ru/yandex/qatools/embed/postgresql/TestPsqlExport.java
@@ -1,11 +1,14 @@
 package ru.yandex.qatools.embed.postgresql;
 
+import java.nio.file.Files;
 import org.junit.Test;
 
 import java.io.File;
 
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -38,6 +41,72 @@ public class TestPsqlExport extends AbstractPsqlTest {
             assertTrue(dataExportDump.length() > 0);
         } finally {
             assertTrue(dataExportDump.delete());
+        }
+    }
+
+    @Test
+    public void testPsqlExportWithArgs() throws Exception {
+        process.importFromFile(new File("src/test/resources/test.backup"));
+        assertThat(conn, not(nullValue()));
+
+        {
+            File fullExportDump = Files.createTempDirectory("psql_export_full_dump").toFile();
+            try {
+                process
+                    .exportToFileWithArgs(fullExportDump,
+                        "--no-privileges",
+                        "--no-owner",
+                        "--format",
+                        "directory");
+                final File[] filesInDumpDir = fullExportDump.listFiles();
+                assertNotNull(filesInDumpDir);
+                assertNotEquals(0, filesInDumpDir.length);
+                for (final File file : filesInDumpDir) {
+                    assertNotEquals(0, file.length());
+                }
+            } finally {
+                deleteDir(fullExportDump);
+            }
+        }
+
+        {
+            File schemeDump = Files.createTempDirectory("psql_export_scheme_dump").toFile();
+            try {
+                process
+                    .exportSchemeToFileWithArgs(schemeDump,
+                        "--no-privileges",
+                        "--no-owner",
+                        "--format",
+                        "directory");
+                final File[] filesInDumpDir = schemeDump.listFiles();
+                assertNotNull(filesInDumpDir);
+                assertNotEquals(0, filesInDumpDir.length);
+                for (final File file : filesInDumpDir) {
+                    assertNotEquals(0, file.length());
+                }
+            } finally {
+                deleteDir(schemeDump);
+            }
+        }
+
+        {
+            File dataExportDump = Files.createTempDirectory("psql_export_data_dump").toFile();
+            try {
+                process
+                    .exportSchemeToFileWithArgs(dataExportDump,
+                        "--no-privileges",
+                        "--no-owner",
+                        "--format",
+                        "directory");
+                final File[] filesInDumpDir = dataExportDump.listFiles();
+                assertNotNull(filesInDumpDir);
+                assertNotEquals(0, filesInDumpDir.length);
+                for (final File file : filesInDumpDir) {
+                    assertNotEquals(0, file.length());
+                }
+            } finally {
+                deleteDir(dataExportDump);
+            }
         }
     }
 }


### PR DESCRIPTION
Hi there!

My use case is to export without owner or privileges statements, and also to export to a directory instead of a SQL file. But I notice the `PostgresProcess#export*ToFile` utility methods do not support such capabilities, unlike what is done in the `PostgresProcess#importFromFileWithArgs` method.

This PR attempts to generalize that idea by supporting any user-defined custom arguments, provided they are compliant with the already existing default options passed to pg_dump.

Thanks.